### PR TITLE
Iterative parallel foreach

### DIFF
--- a/apps/cello_foreach/kernel.cpp
+++ b/apps/cello_foreach/kernel.cpp
@@ -4,29 +4,33 @@
 #include <util/statics.hpp>
 #include <global_pointer/global_pointer.hpp>
 DRAM(std::atomic<int>) sum, mask;
-
+static constexpr int N = 128;
 extern "C" int cello_main(int argc, char **argv)
 {
     using namespace cello;
     mask = (1 << __bsg_id);
     sum = 0;
-    cello::parallel_foreach(0, 64, [](int i) {
+    cello::parallel_foreach(0, N, [](int i) {
+        unsigned sp;
+        asm volatile ("mv %0, sp" : "=r"(sp));
+        bsg_print_hexadecimal(sp);
+        
         bsg_global_pointer::pod_address origin;
         origin.set_pod_x(0).set_pod_y(0);
         bsg_global_pointer::pod_address_guard grd(origin);
         sum += i;
         mask |= (1 << __bsg_id);
     });
-    TEST_EQ(INT, sum, 2016);
+    TEST_EQ(INT, sum, N*(N-1)/2);
     TEST_NEQ(INT, mask, (1 << __bsg_id));
 
     mask = (1 << __bsg_id);
     sum = 0;
-    cello::foreach<cello::serial>(0, 64, [](int i) {
+    cello::foreach<cello::serial>(0, N, [](int i) {
         sum += i;
         mask |= (1 << __bsg_id);
     });
-    TEST_EQ(INT, sum, 2016);
+    TEST_EQ(INT, sum, N*(N-1)/2);
     TEST_EQ(INT, mask, (1 << __bsg_id));
     return 0;
 }

--- a/apps/cello_spgemm/common.hpp
+++ b/apps/cello_spgemm/common.hpp
@@ -5,7 +5,7 @@
 #include <util/list.hpp>
 #ifndef HOST
 #include <utility>
-//#define USE_RB_TREE
+#define USE_RB_TREE
 #ifdef USE_RB_TREE
 #include "rb_tree.hpp"
 #else

--- a/apps/cello_spgemm/kernel.cpp
+++ b/apps/cello_spgemm/kernel.cpp
@@ -128,9 +128,10 @@ inline void exclusive_scan
     dbg("exclusive_scan: tree[0]=%d\n", tree[0]);
     
     // update with offset for each region
-    cello::foreach<cello::parallel>(static_cast<index_type>(0ul),
-                                    static_cast<index_type>(REGIONS),
-                                    [=](index_type tid){
+    cello::foreach<cello::parallel>
+        (static_cast<index_type>(0ul),
+         static_cast<index_type>(REGIONS),
+         [=](index_type tid){
         // calculate range
         index_type region_size = (n + (REGIONS-1))/REGIONS;
         index_type start = tid * region_size;
@@ -169,6 +170,7 @@ int cello_main(int argc, char *argv[])
 {
     dbg("A: %d rows, %d columns, %d non-zeros\n", A.rows(), A.cols(), A.nnz());
     dbg("B: %d rows, %d columns, %d non-zeros\n", B.rows(), B.cols(), B.nnz());
+    bsg_print_hexadecimal(0xa);
     C_product.foreach([](int i, partial_table *& result) {
         partial_table *accum = static_cast<partial_table*>(cello::allocate(sizeof(partial_table)));
         new (accum) partial_table();
@@ -212,7 +214,7 @@ int cello_main(int argc, char *argv[])
         }
         result = accum;
     });
-
+    bsg_print_hexadecimal(0xb);
     cello::on_every_pod([](){
         exclusive_scan
             (C_product.data(),
@@ -231,7 +233,7 @@ int cello_main(int argc, char *argv[])
             }
         }
     });
-
+    bsg_print_hexadecimal(0xc);
     C_product.foreach([](index_type i, partial_table * nonzeros) {
         auto [C_idx_p, _, C_val_p, __] = C.inner_indices_values_range_lcl(i);
 #ifdef USE_RB_TREE
@@ -250,5 +252,6 @@ int cello_main(int argc, char *argv[])
         }
 #endif
     });
+    bsg_print_hexadecimal(0xd);
     return 0;
 }

--- a/apps/cello_spgemm/rb_tree.hpp
+++ b/apps/cello_spgemm/rb_tree.hpp
@@ -356,7 +356,7 @@ public:
     static bool is_red(node *n) { return node::is_red(n); }
 
     node *curr = nullptr;
-    std::array<node *, 20> stack;
+    std::array<node *, 40> stack;
     size_t end = 0;
 };
 #endif

--- a/lib/cello/host/cello_program.cpp
+++ b/lib/cello/host/cello_program.cpp
@@ -29,7 +29,7 @@ int program::input() {
     {
         hb_mc_coordinate_t pod = hb_mc_index_to_coordinate(pod_id, this->mc.mc->config.pods);
 
-        this->cfgs[pod_id].dram_buffer_size() = 16*1024*1024;
+        this->cfgs[pod_id].dram_buffer_size() = 128*1024*1024;
         BSG_CUDA_CALL(hb_mc_device_pod_malloc(&this->mc, pod_id, this->cfgs[pod_id].dram_buffer_size(), &this->cfgs[pod_id].dram_buffer()));
         this->cfgs[pod_id].pod_x() = pod.x;
         this->cfgs[pod_id].pod_y() = pod.y;

--- a/lib/cello/loop_info.hpp
+++ b/lib/cello/loop_info.hpp
@@ -62,6 +62,18 @@ public:
     }
 
     /**
+     * @brief get the height of the tree
+     */
+    IdxT height() const {
+        IdxT j = 0;
+        IdxT l = leafs();
+        while (l > (1<<j)) {
+            j = j+1;
+        }
+        return j;
+    }
+
+    /**
      * @brief Get a loop_info for the lower half
      */
     loop_info lower() const {

--- a/lib/cello/parallel_foreach.hpp
+++ b/lib/cello/parallel_foreach.hpp
@@ -31,6 +31,7 @@ struct parallel_foreach_child {
 template <typename Idx, typename Body>
 void parallel_foreach(loop_info<Idx> &info, Body &&body)
 {
+#ifdef CELLO_PARALLEL_FOREACH_RECURSE
     if (info.leafs() <= 1) {
         for (Idx i = info.start(); i < info.stop(); i += info.step()) {
             body(i);
@@ -40,6 +41,29 @@ void parallel_foreach(loop_info<Idx> &info, Body &&body)
             (parallel_foreach_child<Idx,Body>(info.lower(), std::forward<Body>(body)),
              parallel_foreach_child<Idx,Body>(info.upper(), std::forward<Body>(body)));
     }
+#else
+    using joiner = n_child_joiner;
+    joiner j;
+    joiner *jp = bsg_tile_group_remote_pointer<joiner>(__bsg_x, __bsg_y, &j);
+    Idx h = info.height();
+    task **tpv = static_cast<task**>(cello::allocate(sizeof(task*)*h));
+    size_t k = 0;
+    while (info.leafs() > 1) {
+        task *tp = new_task(parallel_foreach_child<Idx,Body>(info.lower(), std::forward<Body>(body)),
+                            *jp);
+        spawn(tp);
+        tpv[k++] = tp;
+        info = info.upper();
+    }
+    for (Idx i = info.start(); i < info.stop(); i+= info.step()) {
+        body(i);
+    }
+    wait(jp);
+    for (k = 0; k < h; k++) {
+        delete tpv[k];
+    }
+    cello::deallocate(tpv, sizeof(task*)*h);
+#endif
 }
 
 /**

--- a/lib/datastructure/vector.hpp
+++ b/lib/datastructure/vector.hpp
@@ -60,7 +60,8 @@ public:
             size_t start = STRIDE * pod_id();
             size_t step = STRIDE * num_pods();
             size_t end = size();
-            cello::foreach(start, end, step, [this, f](size_t i){
+            cello::foreach<cello::parallel>
+                (start, end, step, [this, f](size_t i){
                 size_t start = i;
                 size_t stop = i + STRIDE;
                 if (stop > size()) {


### PR DESCRIPTION
* Iterative parallel foreach
* Increases size of allocator buffers to 128MB / pod
* Can run a scale 15 sparse matrix product.